### PR TITLE
Fix not being able to deriveToMap alone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Implements the public traits that developers inherit from in order to properly utilize the
 //! derive macro's functionality in code conversion and generation.
-
+#![doc = include_str!("../README.md")]
+//!
 pub mod value;
 
 use std::collections::BTreeMap;

--- a/structmap-derive/src/lib.rs
+++ b/structmap-derive/src/lib.rs
@@ -148,18 +148,18 @@ pub fn to_map(input_struct: TokenStream) -> TokenStream {
 
         impl #impl_generics ToMap for #name #ty_generics #where_clause {
 
-            fn to_stringmap(mut input_struct: #name) -> StringMap {
-                let mut map = StringMap::new();
+            fn to_stringmap(mut input_struct: #name) -> structmap::StringMap {
+                let mut map = structmap::StringMap::new();
                 #(
                     map.insert(#keys.to_string(), input_struct.#idents.to_string());
                 )*
                 map
             }
 
-            fn to_genericmap(mut input_struct: #name) -> GenericMap {
-                let mut map = GenericMap::new();
+            fn to_genericmap(mut input_struct: #name) -> structmap::GenericMap {
+                let mut map = structmap::GenericMap::new();
                 #(
-                    map.insert(#keys.to_string(), Value::new(input_struct.#idents));
+                    map.insert(#keys.to_string(), structmap::value::Value::new(input_struct.#idents));
                 )*
                 map
             }


### PR DESCRIPTION
## Can't derive just `ToMap`
I found an issue when a struct derives `ToMap`  but not `FromMap` like in the following snippet:
```rust
  use structmap::ToMap;
  use structmap_derive::ToMap;

  #[derive(ToMap, Default)] //   <-------- NOT deriving FromMap here
  struct TestStruct {
      name: String,
      value: i64,
  }
```

Turns out once `FromMap`  expands it brings a few things into scope (see [relevant lines](https://github.com/ex0dus-0x/structmap/blob/bd8c3c832803e8b29791723be37cfa2fc6e62455/structmap-derive/src/lib.rs#L64-L65))
To fix this issue I added the missing paths (see commit 943f4a662).

## Fix docs

With that fixed I took the liberty of updating the README.md since it's outdated and might confuse people (it confused me 😅). The README.md should now by included as part of the crate docs and  be compiled with `cargo test` so it should help to keep them in sync. This is using the include_str! macro in docs so it requires [v1.54](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros)

