### PR TITLE
Implemented StringMap and Removed Panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.idea

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ fn main() {
 
     // convert struct to generic map, and check attributes
     let hm: BTreeMap<String, Value> = TestStruct::to_genericmap(test_struct);
-    assert!(hm.get("name").unwrap().string().unwrap() == "example");
+    assert!(hm.get("name").unwrap().String().unwrap() == "example");
     assert!(hm.get("value").unwrap().i64().unwrap() == 0);
 
     let test_struct = TestStruct {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub type GenericMap = BTreeMap<String, Value>;
 pub trait FromMap: Default {
     /// Converts a `GenericMap` back into a structure.
     /// __Constraints__: assumes that value types conform to the original types of the struct.
+    fn from_stringmap(hashmap: StringMap) -> Self;
     fn from_genericmap(hashmap: GenericMap) -> Self;
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -83,7 +83,8 @@ impl Value {
         }
     }
 
-    pub fn string(&self) -> Option<String> {
+    #[allow(non_snake_case)]
+    pub fn String(&self) -> Option<String> {
         if let Value::String(string) = self {
             Some(string.to_string())
         } else {

--- a/structmap-derive/src/lib.rs
+++ b/structmap-derive/src/lib.rs
@@ -46,7 +46,7 @@ pub fn from_map(input: TokenStream) -> TokenStream {
                 // TODO: genericized numerics
 
                 // get the type of the specified field, lowercase
-                let typename: String = quote! {#typepath}.to_string().to_lowercase();
+                let typename: String = quote! {#typepath}.to_string();
 
                 // initialize new Ident for codegen
                 Ident::new(&typename, Span::mixed_site())
@@ -66,24 +66,22 @@ pub fn from_map(input: TokenStream) -> TokenStream {
 
         impl #impl_generics FromMap for #name #ty_generics #where_clause {
 
-            /* FIXME
             fn from_stringmap(mut hashmap: StringMap) -> #name {
                 let mut settings = #name::default();
                 #(
                     match hashmap.entry(String::from(#keys)) {
-                        ::std::collections::hash_map::Entry::Occupied(entry) => {
-                            let value = match entry.get() {
-                                Some(val) => val.parse::<#typecalls>().unwrap(),
-                                None => unreachable!()
+                        ::std::collections::btree_map::Entry::Occupied(entry) => {
+                            let value = match entry.get().parse::<#typecalls>() {
+                                Ok(val) => val,
+                                _ => panic!("Cannot parse out map entry")
                             };
                             settings.#idents = value;
                         },
-                        _ => unreachable!()
+                        _ => ()
                     }
                 )*
                 settings
             }
-            */
 
             fn from_genericmap(mut hashmap: GenericMap) -> #name {
                 let mut settings = #name::default();
@@ -97,7 +95,7 @@ pub fn from_map(input: TokenStream) -> TokenStream {
                             };
                             settings.#idents = value;
                         },
-                        _ => panic!("Cannot parse out map entry"),
+                        _ => (),
                     }
                 )*
                 settings

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,7 +18,6 @@ impl Default for TestStruct {
     }
 }
 
-/*
 #[test]
 fn test_stringmap_to_struct() {
     let mut hm = StringMap::new();
@@ -29,7 +28,7 @@ fn test_stringmap_to_struct() {
     assert!(test.name == "example");
     assert!(test.value == 0);
 }
-*/
+
 
 #[test]
 fn test_genericmap_to_struct() {
@@ -62,7 +61,7 @@ fn test_struct_to_genericmap() {
     };
 
     let hm = TestStruct::to_genericmap(test_struct);
-    assert!(hm.get("name").unwrap().string().unwrap() == "example");
+    assert!(hm.get("name").unwrap().String().unwrap() == "example");
     assert!(hm.get("value").unwrap().i64().unwrap() == 0);
 }
 


### PR DESCRIPTION
Implemented from_stringmap functionality.
Removed Panic from struct field not found, panic at this point its very hard to handle.

Shoult i add a new parameter to configure the panic handling or use Result as return instead the Struct itself?